### PR TITLE
Force pushing to GitHub pages

### DIFF
--- a/travis/deploy-gh-pages.sh
+++ b/travis/deploy-gh-pages.sh
@@ -2,20 +2,21 @@ git remote add -t gh-pages -f origin-gh-pages https://github.com/${TRAVIS_REPO_S
 git fetch origin-gh-pages
 git checkout gh-pages
 git checkout ${TRAVIS_BRANCH} -- ./docs
-mv docs/* . 
+rm -fr ./_static
+mv docs/* . -f
 git rm -r docs
 
 if [ "${TRAVIS_BRANCH}" == "master" ]
-then 
+then
   export VERSION="latest"
-else 
+else
   export VERSION="${TRAVIS_BRANCH}"
 fi
 node_modules/.bin/aglio -i api.apib -o apiary_${VERSION}.html
 
 git add apiary_${VERSION}.html
-git commit -m 'Updating gh-pages'
-git push http://${GITHUB_TOKEN}:x-oauth-basic@github.com/${TRAVIS_REPO_SLUG} gh-pages
+git commit -m 'Updating gh-pages' --amend
+git push --force http://${GITHUB_TOKEN}:x-oauth-basic@github.com/${TRAVIS_REPO_SLUG} gh-pages
 git checkout -- .
 git clean -fd
 git checkout ${TRAVIS_BRANCH}


### PR DESCRIPTION
This PR changes a bit how apiary render is deployed - now it's force pushed to that branch, instead of a simple commit.

This is connected to dojot/dojot#403