### PR TITLE
Fixes parsing of authorization header

### DIFF
--- a/orchestrator/auth.js
+++ b/orchestrator/auth.js
@@ -25,7 +25,7 @@ class InvalidTokenError {
 }
 
 function authParse(req, res, next) {
-  const rawToken = req.header('authorization');
+  const rawToken = req.get('authorization');
   if (rawToken === undefined) {
     return next();
   }
@@ -52,7 +52,7 @@ function authEnforce(req, res, next) {
 
   if (req.user === undefined || req.user.trim() === "" ) {
     // valid token must be supplied
-    console.error("Got invalid request: user is not defined in token: ", req.header('authorization'));
+    console.error("Got invalid request: user is not defined in token: ", req.get('authorization'));
     return res.status(401).send(new UnauthorizedError());
   }
 


### PR DESCRIPTION
HTTP headers should be case insensitive.
This changes the API used to access the `authorization` header, to leverage the already implemented mechanism in express.

This is connected to dojot/flowbroker#28