### PR TITLE
Reorganizes the library

### DIFF
--- a/lib/ContextManagerClient.js
+++ b/lib/ContextManagerClient.js
@@ -4,6 +4,13 @@ var zmq = require('zeromq');
 var uuidv4 = require('uuid/v4');
 
 module.exports = class ContextManagerClient {
+  /**
+   * 
+   * @param {*} contextManagerHost The context manager address
+   * @param {*} contextManagerPort The context manager port
+   * @param {*} responseTimeout Response Timeout. How long the client should wait
+   * for a response (to save/get a context). This time value is in ms.
+   */
   constructor(contextManagerHost, contextManagerPort, responseTimeout) {
     this.contextMap = {};
     this.contextResponseTimeout = responseTimeout; // time in ms

--- a/lib/DataHandlerBase.js
+++ b/lib/DataHandlerBase.js
@@ -1,0 +1,108 @@
+"use strict";
+
+var ContextHandler = require('./ContextHandler.js');
+
+module.exports = class DataHandlerBase {
+
+    /**
+     * Returns full path to html file
+     * @return {string} A string with the path to html file
+     */
+    getNodeRepresentationPath() {
+        throw new Error('You have to implement the method getNodeRepresentationPath!');
+    }
+
+    /**
+     * Returns node metadata information
+     * This may be used by orchestrator as a liveliness check
+     * @return {object} An object with the following attributes
+     *    'id':  ID can actually be any unique human-friendly string
+     *           on proper node-red modules it is "$module/$name"
+     *    'name': This is usually the name of the node
+     *    'module': This is usually the name of the node (as in npm) module
+     *    'version': This is the node's version
+     */
+    getMetadata() {
+        throw new Error('You have to implement the method getMetadata!');
+    }
+
+    /**
+     * Returns object with locale data (for the given locale)
+     * @param  {string} locale Locale string, such as "en-US"
+     * @return {object}        Locale settings used by the module
+     * todo: give more information about the return
+     */
+    getLocaleData() {
+        throw new Error('You have to implement the method getLocaleData!');
+    }
+
+    /**
+     * Statelessly handle a single given message, using given node configuration parameters
+     *
+     * This method should perform all computation required by the node, transforming its inputs
+     * into outputs. When such processing is done, the node should issue a call to the provided
+     * callback, notifying either failure to process the message with given config, or the set
+     * of transformed messages to be sent to the flow's next hop.
+     *
+     * @param  {object}       config   Node configuration to be used for this message
+     * @param  {object}       message  Message to be processed
+     * @param  {Function}     callback Callback to call upon processing completion
+     * @param  {object}       contextHandler An object to deal with the context, if necessary.
+     * See the class ContextHandler to more details
+     * @param  {object}       metadata An object with the metadata from this execution
+     * It is possible to retrieve the following attributes:
+     * - tenant
+     * - flowId
+     * - originatorDeviceId
+     * @return {undefined}
+     * todo: give more information about the config, message and callback
+     * parameters
+     */
+    handleMessage(config, message, callback, metadata, contextHandler) {
+        throw new Error('You have to implement the method handleMessage!');
+    }
+
+    /**
+     *
+     * @param {string} field Path to field to be set
+     * @param {string} value Value to set field to
+     * @param {object} target Object to be modified
+     */
+    _set(field, value, target) {
+        let source = field.match(/([^.]+)/g);
+        let key = source.shift();
+        let at = target;
+        while (key) {
+            if (source.length) {
+            if (!at.hasOwnProperty(key)) {
+                at[key] = {};
+            }
+            at = at[key];
+            } else {
+            at[key] = value;
+            }
+            key = source.shift();
+        }
+    }
+
+    /**
+     *
+     * @param {string} field Path to field to be set
+     * @param {object} target Object to read from
+     */
+    _get(field, target) {
+        let source = field.match(/([^.]+)/g);
+        let at = source.shift();
+        let data = target;
+        while (at) {
+            if (!data.hasOwnProperty(at)) {
+            throw new Error(`Unknown property ${field} requested`);
+            }
+
+            data = data[at];
+            at = source.shift();
+        }
+
+        return data;
+    }
+}

--- a/lib/DataHandlerBase.js
+++ b/lib/DataHandlerBase.js
@@ -1,7 +1,5 @@
 "use strict";
 
-var ContextHandler = require('./ContextHandler.js');
-
 module.exports = class DataHandlerBase {
 
     /**
@@ -58,6 +56,7 @@ module.exports = class DataHandlerBase {
      * todo: give more information about the config, message and callback
      * parameters
      */
+    /* eslint no-unused-vars: ["error", { "args": "none" }] */
     handleMessage(config, message, callback, metadata, contextHandler) {
         throw new Error('You have to implement the method handleMessage!');
     }

--- a/lib/DojotHandler.js
+++ b/lib/DojotHandler.js
@@ -11,7 +11,7 @@ function checkField(target, field, message) {
   }
 }
 
-class DojotHandler {
+module.exports = class DojotHandler {
   constructor(dataHandler,
       contextResponseTimeout,
       contextManagerHost,
@@ -23,7 +23,7 @@ class DojotHandler {
     let ctxManagerPort = contextManagerPort || 5556;
 
     this.handler = dataHandler;
-    this.handleResults = this.handleResults.bind(this);
+    this._handleResults = this._handleResults.bind(this);
     this.contextManager = new ContextManagerClient(ctxManagerHost,
                                                    ctxManagerPort,
                                                    ctxResponseTimeout);
@@ -45,7 +45,7 @@ class DojotHandler {
       try {
         data = JSON.parse(request.toString());
       } catch (error) {
-        return this.handleResults(new Error("Payload must be valid json"));
+        return this._handleResults(new Error("Payload must be valid json"));
       }
 
       try {
@@ -53,22 +53,22 @@ class DojotHandler {
         console.log('Got message. invoking handler ...', data);
         switch (data.command) {
           case 'locale':
-            this.handleLocale(data);
+            this._handleLocale(data);
             break;
           case 'metadata':
-            this.handleMetadata(data);
+            this._handleMetadata(data);
             break;
           case 'message':
-            this.handleMessage(data);
+            this._handleMessage(data);
             break;
           case 'html':
-            this.handleHtml(data);
+            this._handleHtml(data);
             break;
           default:
-            this.handleResults(new Error("Unknown command requested"));
+            this._handleResults(new Error("Unknown command requested"));
         }
       } catch (error) {
-        return this.handleResults(error);
+        return this._handleResults(error);
       }
     });
 
@@ -92,7 +92,7 @@ class DojotHandler {
     this.isInitialized = true;
   }
 
-  handleResults(error, response) {
+  _handleResults(error, response) {
     if (error) {
       console.error("Message processing failed", error);
       return this.commandSocket.send(JSON.stringify({"error": error.message}));
@@ -103,75 +103,26 @@ class DojotHandler {
     return this.commandSocket.send(output);
   }
 
-  handleHtml() {
+  _handleHtml() {
     const path = this.handler.getNodeRepresentationPath();
     const html = fs.readFileSync(path);
-    this.handleResults(undefined, { payload: html.toString('utf8') });
+    this._handleResults(undefined, { payload: html.toString('utf8') });
   }
 
-  handleMetadata() {
-    this.handleResults(undefined, { payload: this.handler.getMetadata() });
+  _handleMetadata() {
+    this._handleResults(undefined, { payload: this.handler.getMetadata() });
   }
 
-  handleLocale(data) {
+  _handleLocale(data) {
     checkField(data, 'locale', "Missing locale to be returned");
-    this.handleResults(undefined, { payload: this.handler.getLocaleData(data.locale)});
+    this._handleResults(undefined, { payload: this.handler.getLocaleData(data.locale)});
   }
 
-  handleMessage(data) {
+  _handleMessage(data) {
     checkField(data, 'config', "Missing node config to be used");
     checkField(data, 'message', "Missing message to be processed");
     checkField(data, 'metadata', "Missing metadata to be processed");
 
-    this.handler.handleMessage(data.config, data.message, this.handleResults, data.metadata, this.contextHandler);
+    this.handler.handleMessage(data.config, data.message, this._handleResults, data.metadata, this.contextHandler);
   }
 }
-
-class DataHandlerBase {
-
-  /**
-   *
-   * @param {string} field Path to field to be set
-   * @param {string} value Value to set field to
-   * @param {object} target Object to be modified
-   */
-  _set(field, value, target) {
-    let source = field.match(/([^.]+)/g);
-    let key = source.shift();
-    let at = target;
-    while (key) {
-      if (source.length) {
-        if (!at.hasOwnProperty(key)) {
-          at[key] = {};
-        }
-        at = at[key];
-      } else {
-        at[key] = value;
-      }
-      key = source.shift();
-    }
-  }
-
-  /**
-   *
-   * @param {string} field Path to field to be set
-   * @param {object} target Object to read from
-   */
-  _get(field, target) {
-    let source = field.match(/([^.]+)/g);
-    let at = source.shift();
-    let data = target;
-    while (at) {
-      if (!data.hasOwnProperty(at)) {
-        throw new Error(`Unknown property ${field} requested`);
-      }
-
-      data = data[at];
-      at = source.shift();
-    }
-
-    return data;
-  }
-}
-
-module.exports = { DojotHandler: DojotHandler, DataHandlerBase: DataHandlerBase };

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,4 @@
+module.exports.DojotHandler = require("./DojotHandler.js");
+module.exports.ContextHandler = require("./ContextHandler.js");
+module.exports.DataHandlerBase = require("./DataHandlerBase.js");
+module.exports.ContextManagerClient = require("./ContextManagerClient.js");

--- a/lib/package.json
+++ b/lib/package.json
@@ -2,7 +2,7 @@
   "name": "@dojot/flow-node",
   "version": "1.1.0",
   "description": "Basic interface to dojot's flowbroker",
-  "main": "CommandHandler.js",
+  "main": "index.js",
   "scripts": {
     "test": ""
   },


### PR DESCRIPTION
- Moves DataHandlerBase class from CommandHandler.js to DataHandlerBase.js
- Renames the CommandHandler.js to DojotHandler.js
- Copies documentation from example to DataHandlerBase
- Adds methods that must be implemented to DataHandlerBase class
- Changes the library's main module to index.js
- Adds the prefix _ to the DojotHandler private methods