### PR TITLE
Remove unnecessary promise wrapping of an already promise-based method

### DIFF
--- a/lib/ContextHandler.js
+++ b/lib/ContextHandler.js
@@ -52,12 +52,7 @@ module.exports = class ContextHandler {
    *   gives a string the describes the error
    */
   getFlowContext(contextName, tenant, flowId) {
-    return new Promise ((resolve, reject) => {
-      this.client.getContext(tenant + '/' + flowId + '/' + contextName).then(
-        (values) => { resolve(values); },
-        (error) => { reject(error); }
-      );
-    });
+    return this.client.getContext(tenant + '/' + flowId + '/' + contextName);
   }
   
   /**
@@ -77,12 +72,7 @@ module.exports = class ContextHandler {
    *   gives a string the describes the error
    */
   getNodeContext(contextName, tenant, flowId, node) {
-    return new Promise ((resolve, reject) => {
-      this.client.getContext(tenant + '/' + flowId + '/' + node + '/' + contextName).then(
-        (values) => { resolve(values); },
-        (error) => { reject(error); }
-      )
-    });
+    return this.client.getContext(tenant + '/' + flowId + '/' + node + '/' + contextName);
   }
   
   /**
@@ -102,13 +92,8 @@ module.exports = class ContextHandler {
    *   gives a string the describes the error
    */
   getNodeInstanceContext(contextName, tenant, flowId, node, nodeInstance) {
-    return new Promise ((resolve, reject) => {
-      this.client.getContext(tenant + '/' + flowId + '/' + node + '/' +
-        nodeInstance + '/' + contextName).then(
-          (values) => { resolve(values); },
-          (error) => { reject(error); }
-        );
-    });
+    let contextName = tenant + '/' + flowId + '/' + node + '/' + nodeInstance + '/' + contextName;
+    return this.client.getContext(contextName);
   }
 
   /**
@@ -122,12 +107,7 @@ module.exports = class ContextHandler {
    *   gives a string the describes the error
    */
   saveContext(contextId, contextContent) {
-    return new Promise ((resolve, reject) => {
-      this.client.saveContext(contextId, contextContent).then(
-        () => { resolve(); },
-        (error) => { reject(error); }
-      );
-    });  
+    return this.client.saveContext(contextId, contextContent).then(() => {});
   }
 
 } // class

--- a/lib/ContextHandler.js
+++ b/lib/ContextHandler.js
@@ -92,8 +92,7 @@ module.exports = class ContextHandler {
    *   gives a string the describes the error
    */
   getNodeInstanceContext(contextName, tenant, flowId, node, nodeInstance) {
-    let contextName = tenant + '/' + flowId + '/' + node + '/' + nodeInstance + '/' + contextName;
-    return this.client.getContext(contextName);
+    return this.client.getContext(tenant + '/' + flowId + '/' + node + '/' + nodeInstance + '/' + contextName);
   }
 
   /**

--- a/orchestrator/executor.js
+++ b/orchestrator/executor.js
@@ -13,14 +13,11 @@ module.exports = class Executor {
     }
 
     init() {
-        return new Promise((resolve, reject) => {
-            this.producer.connect().then(() => {
+        return this.producer
+            .connect()
+            .then(() => {
                 this.consumer.connect();
-                resolve();
-            }).catch((error) => {
-                reject(error);
             });
-        });
     }
 
     hop(data, ack) {

--- a/orchestrator/flowManager.js
+++ b/orchestrator/flowManager.js
@@ -138,29 +138,26 @@ class FlowManager {
   }
 
   removeAll() {
-    return new Promise((resolve, reject) => {
-      this.collection.deleteMany({}).then(() => {
-        resolve();
-      }).catch((error) => {
-        reject(error);
-      });
-    });
+    return this.collection
+      .deleteMany({})
+      .then(() => {});
   }
 
   get(flowid) {
-    return new Promise((resolve, reject) => {
-      this.collection.findOne({id: flowid}).then((flow) => {
+    return this.collection
+      .findOne({id: flowid})
+      .then(flow => {
         if (!flow) {
-          reject(new UnknownFlowError(flowid));
+          throw new UnknownFlowError(flowid);
         }
 
-        resolve(flow);
-      }).catch((error) => {
+        return flow;
+      })
+      .catch(error => {
         if (error instanceof mongo.MongoError){
-          reject(error);
+          throw error;
         }
       });
-    });
   }
 
   create(label, enabled, flow) {
@@ -212,8 +209,8 @@ class FlowManager {
   }
 
   set(flowid, label, enabled, flow){
-    return new Promise((resolve, reject) => {
-      this.get(flowid).then((oldFlow) => {
+    return this.get(flowid)
+      .then(oldFlow => {
         let newFlow = JSON.parse(JSON.stringify(oldFlow));
         newFlow.created = oldFlow.created;
         newFlow.updated = new Date();
@@ -230,33 +227,28 @@ class FlowManager {
         if (label) { newFlow.label = label; }
         if (enabled) { newFlow.enabled = enabled; }
 
-        this.collection.findOneAndReplace({id: flowid}, newFlow).then((result) => {
+        return this.collection
+          .findOneAndReplace({id: flowid}, newFlow)
+          .then(result => {
           if (result.ok === 1) {
-            resolve(newFlow);
+              return newFlow;
           }
-          reject(new MongoError());
-        }).catch((error) => {
-          reject(error);
-        });
-      }).catch((error) => {
-        reject(error);
+            throw new MongoError();
       });
     });
   }
 
   remove(flowid) {
-    return new Promise((resolve, reject) => {
-      this.collection.findOneAndDelete({id: flowid}).then((flow) => {
+    return this.collection
+      .findOneAndDelete({id: flowid})
+      .then((flow) => {
         if (flow.value === null) {
-          reject(new UnknownFlowError(flowid));
+          throw new UnknownFlowError(flowid);
         } else if (flow.ok === 1) {
-          resolve(flow.value);
+          return flow.value;
         } else {
-          reject(new MongoError());
+          throw new Error(new MongoError());
         }
-      }).catch((error) => {
-        reject(error);
-      });
     });
   }
 

--- a/orchestrator/ingestor.js
+++ b/orchestrator/ingestor.js
@@ -25,15 +25,8 @@ module.exports = class DeviceIngestor {
    * @return {[Promise]}  List of known tenants in the platform
    */
   listTenants() {
-    return new Promise((resolve, reject) => {
-      axios({
-        'url': config.tenancy.manager + '/admin/tenants'
-      }).then((response) => {
-        resolve(response.data.tenants);
-      }).catch((error) => {
-        reject(error);
-      });
-    });
+    let url = config.tenancy.manager + '/admin/tenants';
+    return axios({ url }).then((response) => response.data.tenants);
   }
 
   /**

--- a/orchestrator/kafka.js
+++ b/orchestrator/kafka.js
@@ -20,21 +20,19 @@ class TopicManager {
         const parsedBroker = broker || config.dataBroker.url;
         const parsedGlobal = global ? "?global=true" : "";
         const key = tenant + ':' + subject;
-        return new Promise((resolve, reject) => {
-            if (this.topics.hasOwnProperty(key)) {
-                return resolve(this.topics[key]);
-            }
 
-            axios({
-                'url': parsedBroker + '/topic/' + subject + parsedGlobal,
-                'method': 'get',
-                'headers': { 'authorization': 'Bearer ' + getToken(tenant) }
-            }).then((response) => {
-                this.topics[key] = response.data.topic;
-                resolve(response.data.topic);
-            }).catch((error) => {
-                reject(error);
-            });
+        if (this.topics.hasOwnProperty(key)) {
+            return Promise.resolve(this.topics[key]);
+        }
+
+       return axios({
+            'url': parsedBroker + '/topic/' + subject + parsedGlobal,
+            'method': 'get',
+            'headers': { 'authorization': 'Bearer ' + getToken(tenant) }
+        })
+        .then((response) => {
+            this.topics[key] = response.data.topic;
+            return response.data.topic;
         });
     }
 }

--- a/orchestrator/mongodb.js
+++ b/orchestrator/mongodb.js
@@ -13,18 +13,19 @@ class MongoAbstraction {
   get(url) {
     const target = url || config.mongodb.url;
 
-    return new Promise((resolve, reject) => {
-      if (this.clients.hasOwnProperty(target)) {
-        resolve(this.clients[target]);
-      } else {
-        mongo.MongoClient.connect(target, config.mongodb.opt).then((client) => {
-          this.clients[target] = client;
-          resolve(client);
-        }).catch((error) => {
-          reject(error);
+    return Promise.resolve()
+      .then(() => {
+        if (this.clients.hasOwnProperty(target)) {
+          return this.clients[target];
+        }
+
+        return mongo.MongoClient
+          .connect(target, config.mongodb.opt)
+          .then((client) => {
+            this.clients[target] = client;
+            return client;
+          });
         });
-      }
-    });
   }
 }
 

--- a/orchestrator/nodes/remoteNode/index.js
+++ b/orchestrator/nodes/remoteNode/index.js
@@ -18,19 +18,19 @@ class RemoteNodeHandler extends dojot.DataHandlerBase {
 
   init() {
     // Fetch all meta information from newly created remote impl
-    return new Promise((resolve, reject) => {
-      dispatcher(this.target, {command: 'metadata'}).then((meta) => {
+    return dispatcher(this.target, {command: 'metadata'})
+      .then(meta => {
         this.metadata = meta.payload;
-        dispatcher(this.target, { command: 'html' }).then((html) => {
-          this.html = '/tmp/' + this.target;
-          fs.writeFileSync(this.html, html.payload);
-          dispatcher(this.target, { command: 'locale', locale: 'en-US' }).then((reply) => {
-            this.locale = reply.payload;
-            return resolve();
-          }).catch((error) => { return reject(error); });
-        }).catch((error) => { return reject(error); });
-      }).catch((error) => { return reject(error); });
-    });
+        return dispatcher(this.target, { command: 'html' })
+      })
+      .then(html => {
+        this.html = '/tmp/' + this.target;
+        fs.writeFileSync(this.html, html.payload);
+        return dispatcher(this.target, { command: 'locale', locale: 'en-US' })
+      })
+      .then(reply => {
+        this.locale = reply.payload;
+      });
   }
   getNodeRepresentationPath() {
     return this.html;


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
It removes unnecessary creation of promises objects.


* **What is the current behavior?** (You can also link to an open issue here)
N/A


* **What is the new behavior (if this is a feature change)?**
N/A


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)
Not that I'm aware of.

* **Other information**:

Let's say we have this function that returns a promise which resolves the object `{ foo: true }`:

```js
function promiseFoo() {
   return Promise.resolve({ foo: true });
}
```

If we call this function inside another function whose returned value must be a promise resolving the object `{ foo: true, bar: true }`, we can just do something like this:

```js
function promiseFooBar() {
   return promiseFoo()
      .then(res => {
         return { bar: true, ...res };
      });
}
```

I found out that similar operations in the source code is adding an unnecessary promise wrapper around an already promise-based function. Like this:

```js
function promiseFooBar() {
   return new Promise((resolve) => { // <- unnecessary wrapping 
      promiseFoo().then(res => resolve({ bar: foo, ...res }));
   })
}
```

So, this PR aims to remove those kind of bad patterns. This way we can have a more reliable, readable, and maintainable code.