### PR TITLE
feat: adding response output variable to http node

### DIFF
--- a/orchestrator/nodes/http/http.html
+++ b/orchestrator/nodes/http/http.html
@@ -60,6 +60,11 @@
     </div>
 
     <div class="form-row">
+        <label for="node-input-response"><i class="fa fa-envelope"></i> <span data-i18n="httpin.label.response"></span></label>
+        <input type="text" id="node-input-response" placeholder="Response body">
+    </div>
+    
+    <div class="form-row">
         <label for="node-input-ret"><i class="fa fa-arrow-left"></i> <span data-i18n="httpin.label.return"></span></label>
         <select type="text" id="node-input-ret" style="width:70%;">
         <option value="txt" data-i18n="httpin.utf8"></opti  on>
@@ -141,6 +146,7 @@
             method:{value:"GET"},
             ret: {value:"txt"},
             body: {value:""},
+            response: {value:""},
             url:{value:"",validate:function(v) { return (v.trim().length === 0) || (v.indexOf("://") === -1) || (v.trim().indexOf("http") === 0)} }
             // tls: {type:"tls-config",required: false}
         },
@@ -194,6 +200,7 @@
                 }
             });
             $("#node-input-body").typedInput({default:'msg',types:['msg']});
+            $("#node-input-response").typedInput({default:'msg',types:['msg']});
         },
         oneditsave: function() {
             // if (!$("#node-input-usetls").is(':checked')) {

--- a/orchestrator/nodes/http/index.js
+++ b/orchestrator/nodes/http/index.js
@@ -8,6 +8,7 @@ var http = require("follow-redirects").http;
 var https = require("follow-redirects").https;
 var urllib = require("url");
 var mustache = require("mustache");
+var util = require("util");
 
 var dojot = require('@dojot/flow-node');
 
@@ -184,7 +185,7 @@ class DataHandler extends dojot.DataHandlerBase {
             }
             var urltotest = url;
 
-            logger.debug(`HTTP request about to be sent: ${opts}`);
+            logger.debug(`HTTP request about to be sent: ${util.inspect(opts)}`);
             var req = ((/^https/.test(urltotest)) ? https : http).request(opts, (res) => {
                 // Force NodeJs to return a Buffer (instead of a string)
                 // See https://github.com/nodejs/node/issues/6038
@@ -219,11 +220,9 @@ class DataHandler extends dojot.DataHandlerBase {
                     // be taken. #1344
                     if (Array.isArray(httpResponse.payload)) {
                         // Convert the payload to the required return type
-                        this._set(config.response, Buffer.concat(message.payload), message); // bin
                         if (ret !== "bin") {
                             let strData = httpResponse.payload;
-                            httpResponse.payload = strData.toString("utf8")
-
+                            httpResponse.payload = strData.toString("utf8");
                             if (ret === "obj") {
                                 try {
                                     httpResponse.payload = JSON.parse(strData);

--- a/orchestrator/nodes/http/index.js
+++ b/orchestrator/nodes/http/index.js
@@ -219,7 +219,7 @@ class DataHandler extends dojot.DataHandlerBase {
                     // be taken. #1344
                     if (Array.isArray(httpResponse.payload)) {
                         // Convert the payload to the required return type
-                        // this._set(config.response, Buffer.concat(message.payload), message); // bin
+                        this._set(config.response, Buffer.concat(message.payload), message); // bin
                         if (ret !== "bin") {
                             let strData = httpResponse.payload;
                             httpResponse.payload = strData.toString("utf8")

--- a/orchestrator/nodes/http/locales/en-US/http.json
+++ b/orchestrator/nodes/http/locales/en-US/http.json
@@ -10,6 +10,7 @@
         "headers": "Headers",
         "other": "other",
         "body": "Request body",
+        "response": "Response",
         "name": "Name"
     },
     "setby": "- set by msg.method -",


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


* **What is the current behavior?** (You can also link to an open issue here)
HTTP node doesn't have a nice mechanism to allow responses from HTTP server (for instance, when sending a GET request to an external server). Also, accessing response values is weird ( as pointed out here: dojot/dojot#609)


* **What is the new behavior (if this is a feature change)?**
HTTP node has a nice little box where the user can set which attribute should receive all the response information (called, as one might have guessed, 'Response'). For instance, if this is set to "responseGet", the user can access it by checking "msg.responseGet.X An exemple of such response object is:
```json
{
  "statusCode": 200,
  "headers": {
    "content-type": "text/html; charset=utf-8"
  },
  "responseUrl": "http://172.18.0.1:10001/test",
  "payload": {
    "answer": "okdok"
  }
}
```


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No, aside of needing to save all flows that uses HTTP requests and their responses.

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)
No

* **Other information**:
