### PR TITLE
Fixing geo node crash when geo attribute is not sent with mqtt message

### DIFF
--- a/orchestrator/nodes/geo/index.js
+++ b/orchestrator/nodes/geo/index.js
@@ -80,7 +80,7 @@ class DataHandler {
         if (!geolocation) {
             logger.debug("... geo node was not successfully executed.");
             logger.error("Message has no geographic position attached.");
-            callback(new Error("Message has no geographic position attached"));
+            return callback(new Error("Message has no geographic position attached"));
         }
 
         let inout = geolib.isPointInside(geolocation, config.points);


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix.


* **What is the current behavior?** (You can also link to an open issue here)
When a MQTT message is sent without a geo attribute to a device that contains a geo attribute, the geo flow node crashes and restarts.


* **What is the new behavior (if this is a feature change)?**
The geo flow node won't crash anymore because of the problem described above.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)
This is connected to dojot/dojot#664.

* **Other information**:
