### PR TITLE
update postgres, waiting services to start

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,10 @@ script:
   - docker build -t dojot/flowbroker -f orchestrator.docker .
   - docker build -t dojot/flowbroker-context-manager -f contextManager.docker .
   - docker build -t tests/flowbroker -f ./tests/Dockerfile .
-  - docker-compose -f tests/docker-compose.yml up -d kafka rabbitmq data-broker mongodb auth flowbroker flowbroker-context-manager flowbroker-redis
+  - docker-compose -f tests/docker-compose.yml up -d kafka rabbitmq data-broker mongodb auth postgres-users
+  - sleep 10
+  - docker-compose -f tests/docker-compose.yml up -d flowbroker flowbroker-context-manager flowbroker-redis
+  - sleep 10
   - docker-compose -f ./tests/docker-compose.yml run --rm tester
 
 after_success:

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -83,6 +83,11 @@ services:
       driver: json-file
       options:
         max-size: 100m
+    ports:
+      - "5672:5672"
+      - "4369:4369"
+      - "5671:5671"
+      - "25672:25672"
 
   zookeeper:
     image: "zookeeper:3.4"
@@ -118,6 +123,7 @@ services:
       - auth-redis
       - postgres
       - apigw
+      - postgres-users
     environment:
       AUTH_DB_HOST: "postgres"
       AUTH_DB_USER: "kong"
@@ -131,16 +137,26 @@ services:
         max-size: 100m
 
   postgres:
-    image: "postgres:9.4"
+    image: postgres:9.4-alpine
     restart: always
-    environment:
-      POSTGRES_USER: "kong"
-      POSTGRES_DB: "kong"
     healthcheck:
       test: ["CMD", "pg_isready", "-U", "postgres"]
       interval: 10s
       timeout: 5s
       retries: 5
+    logging:
+      driver: json-file
+      options:
+        max-size: 100m
+
+  postgres-users:
+    image: postgres:9.4-alpine
+    restart: on-failure
+    command: >
+      bash -c "createuser kong -d -h postgres -U postgres && createdb kong -U kong -h postgres"
+    depends_on:
+      postgres:
+        condition: service_healthy
     logging:
       driver: json-file
       options:
@@ -158,7 +174,7 @@ services:
     restart: on-failure
 
   apigw:
-    image: dojot/kong:latest
+    image: dojot/kong:v0.2.1
     restart: always
     depends_on:
       postgres:


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [NA] Tests for the changes have been added (for bug fixes / features)
- [NA] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR adds a few timed synchronization checkpoints (aka sleeps) in order to properly start services.


* **What is the current behavior?** (You can also link to an open issue here)
All services are started at once. A few of them (particularly rabbitmq) are taking too much time to be started.


* **What is the new behavior (if this is a feature change)?**
All dependencies are started before flowbroker.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)
This is connected to dojot/dojot#762

* **Other information**:
