### PR TITLE
Adds the option in the get-context node to receive the context name from msg

### DIFF
--- a/orchestrator/nodes/get-context/get-context.html
+++ b/orchestrator/nodes/get-context/get-context.html
@@ -18,6 +18,7 @@
     <div class="form-row">
         <label for="node-input-contextName"><i class="fa fa-edit"></i> <span>Context name</span></label>
         <input type="text" id="node-input-contextName" placeholder="Context name" style="width:250px;">
+        <input type="hidden" id="node-input-contextNameType">
     </div>
 
     <!-- Output fields -->
@@ -40,7 +41,8 @@
         defaults: {
             name: { value: "", required: false },
             contextLayer: {value: "tenant", required: true},
-            contextName: {required: true},
+            contextName: {required: true, validate: RED.validators.typedInput("contextNameType")},
+            contextNameType: {value: 'str'},
             contextContent: {required: true}
         },
         inputs: 1,
@@ -53,6 +55,14 @@
             return this.name ? "node_label_italic" : "";
         },
         oneditprepare: function () {
+            if (!this.fieldType) {
+                this.fieldType = 'str';
+            }
+            $("#node-input-contextName").typedInput({
+                default: 'str',
+                types: ['str', 'msg'],
+                typeField: $("#node-input-contextNameType")
+            });
         },
         oneditsave: function () {
         }

--- a/orchestrator/nodes/get-context/get-context.js
+++ b/orchestrator/nodes/get-context/get-context.js
@@ -48,11 +48,16 @@ class DataHandler extends dojot.DataHandlerBase {
   handleMessage(config, message, metadata, contextHandler) {
     return new Promise ( (resolve, reject) => {
       let getContextPromise;
+      let contextName = config.contextName;
+
+      if (config.contextNameType === 'msg') {
+        contextName = this._get(config.contextName, message);
+      }
 
       if (config.contextLayer === 'tenant') {
-        getContextPromise = contextHandler.getTenantContext(metadata.tenant, config.contextName);
+        getContextPromise = contextHandler.getTenantContext(metadata.tenant, contextName);
       } else { // flow layer
-        getContextPromise = contextHandler.getFlowContext(metadata.tenant, metadata.flowId, config.contextName);
+        getContextPromise = contextHandler.getFlowContext(metadata.tenant, metadata.flowId, contextName);
       }
 
       getContextPromise.then( (contextContent) => {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
improvement


* **What is the current behavior?** (You can also link to an open issue here)
The get-context node only accepts to configure the context's name in an explicit way (via string).


* **What is the new behavior (if this is a feature change)?**
The get-context node accepts to configure the context's name in an explicit way (via string) or using a variable (via msg).


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Yes, it impacts who uses the get-context node.

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)


* **Other information**:
