### PR TITLE
Fixed the problem of flowbroker doesn't die in case of failures

### DIFF
--- a/orchestrator.docker
+++ b/orchestrator.docker
@@ -10,6 +10,8 @@ RUN npm install
 
 
 FROM node:8.14.0-alpine
+RUN apk add --no-cache tini
+ENTRYPOINT ["/sbin/tini", "--"]
 
 COPY --from=basis /opt/flowbroker/orchestrator /opt/flowbroker/orchestrator
 WORKDIR /opt/flowbroker/orchestrator

--- a/orchestrator/index.js
+++ b/orchestrator/index.js
@@ -19,7 +19,7 @@ var dojotModule = require("@dojot/dojot-module");
 
 function fail(error) {
   logger.error('[flowbroker] Initialization failed.', error.message);
-  process.exit(1);
+  process.kill(process.pid, "SIGTERM");
 }
 
 class IdleManager {
@@ -188,5 +188,4 @@ kafkaMessenger.init().then(() => {
     ingestor.init();
   }).catch((error) => {
     fail(error);
-    process.kill(process.pid, "SIGTERM");
 });


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug Fix.


* **What is the current behavior?** (You can also link to an open issue here)
In case of failure the node process doesn't die because it runs as PID 1.


* **What is the new behavior (if this is a feature change)?**
Signals can be used to kill the node process.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)
It is related to dojot/dojot/#929

* **Other information**:
