### PR TITLE
Changed to not run context-manager process as PID1

### DIFF
--- a/contextManager.docker
+++ b/contextManager.docker
@@ -10,6 +10,8 @@ RUN npm install
 
 
 FROM node:8.14.0-alpine
+RUN apk add --no-cache tini
+ENTRYPOINT ["/sbin/tini", "--"]
 
 COPY --from=basis /opt/flowbroker/contextManager /opt/flowbroker/contextManager
 WORKDIR /opt/flowbroker/contextManager


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bugfix


* **What is the current behavior?** (You can also link to an open issue here)
The node process run as PID 1 for the context-manager container. This is not adequate once signal handling works different for this PID.


* **What is the new behavior (if this is a feature change)?**
Tini runs as PID 1.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)
No

* **Other information**:
