### PR TITLE
Adds helper to stringify objects on template node

### DIFF
--- a/orchestrator/nodes/template/index.js
+++ b/orchestrator/nodes/template/index.js
@@ -8,6 +8,9 @@ const logger = require("../../logger").logger;
 class DataHandler extends dojot.DataHandlerBase {
     constructor() {
         super();
+        handlebars.registerHelper('stringify', function(context) {
+            return JSON.stringify(context);
+        });
     }
 
     /**

--- a/orchestrator/nodes/template/template.html
+++ b/orchestrator/nodes/template/template.html
@@ -73,7 +73,7 @@
             field: {value:"payload", validate: RED.validators.typedInput("fieldType")},
             fieldType: {value:"msg"},
             syntax: {value:"handlebars"},
-            template: {value:RED._('dojot/template:template_value') + "{{payload}} !"},
+            template: {value:RED._('dojot/template:template_value') + " {{{stringify payload}}} !"},
             output: {value:"str"}
         },
         paletteLabel:  RED._('dojot/template:template'),


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


* **What is the current behavior?** (You can also link to an open issue here)
There is not possible to stringify an object


* **What is the new behavior (if this is a feature change)?**
The possibility to stringify an object. 

For instance: in a template node, the user might want to explicitly add a complex object, such as:

```
This is an example {{ payload }}
```

This will be translated to `This is an example [Object]`. This PR adds a new handlebars helper, `stringify` so that the user can write a template such as: 

```
This is an example {{ stringify payload }}
```

Which will be translated to:

```
This is an example { "attr" : "value", n: 10 }
```


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)


* **Other information**:
