### PR TITLE
Reverts the node 'template' to have the mustache engine again

### DIFF
--- a/orchestrator/nodes/template/index.js
+++ b/orchestrator/nodes/template/index.js
@@ -3,6 +3,7 @@
 const path = require('path');
 const dojot = require('@dojot/flow-node');
 const handlebars = require('handlebars');
+const mustache = require('mustache');
 const logger = require("../../logger").logger;
 
 class DataHandler extends dojot.DataHandlerBase {
@@ -67,11 +68,20 @@ class DataHandler extends dojot.DataHandlerBase {
         try {
             let templateData = config.template;
             let data = '';
-            if (config.syntax === 'handlebars') {
-                let template = handlebars.compile(templateData);
-                data = template(message);
-            } else if (config.syntax === 'plain') {
-                data = config.template;
+            switch(config.syntax) {
+                case 'handlebars':
+                    let template = handlebars.compile(templateData);
+                    data = template(message);
+                break;
+                case 'plain':
+                    data = config.template;
+                break;
+                case 'mustache':
+                    data = mustache.render(templateData, message);
+                break;
+                default:
+                    logger.error(`Unsupported syntax on template node: ${config.syntax}`);
+                    return Promise.reject('configuration error');
             }
 
             if (config.output === 'json') {

--- a/orchestrator/nodes/template/index.js
+++ b/orchestrator/nodes/template/index.js
@@ -69,16 +69,17 @@ class DataHandler extends dojot.DataHandlerBase {
             let templateData = config.template;
             let data = '';
             switch(config.syntax) {
-                case 'handlebars':
+                case 'handlebars': {
                     let template = handlebars.compile(templateData);
                     data = template(message);
-                break;
+                    break;
+                }
                 case 'plain':
                     data = config.template;
-                break;
+                    break;
                 case 'mustache':
                     data = mustache.render(templateData, message);
-                break;
+                    break;
                 default:
                     logger.error(`Unsupported syntax on template node: ${config.syntax}`);
                     return Promise.reject('configuration error');

--- a/orchestrator/nodes/template/locales/en-US.json
+++ b/orchestrator/nodes/template/locales/en-US.json
@@ -7,6 +7,7 @@
     "syntax": "Format",
     "output": "Output as",
     "handlebars": "Handlebars template",
+    "mustache": "Mustache template (deprecated)",
     "plain": "Plain text",
     "json": "Parsed JSON"
   },

--- a/orchestrator/nodes/template/locales/pt-BR.json
+++ b/orchestrator/nodes/template/locales/pt-BR.json
@@ -7,6 +7,7 @@
     "syntax": "Formato",
     "output": "Saída",
     "handlebars": "Handlebars modelo",
+    "mustache": "Mustache modelo (descontinuado)",
     "plain": "Texto simples",
     "json": "JSON analisado"
   },

--- a/orchestrator/nodes/template/template.html
+++ b/orchestrator/nodes/template/template.html
@@ -13,6 +13,7 @@
         <select id="node-input-syntax" style="width:180px;">
             <option value="handlebars" data-i18n="label.handlebars"></option>
             <option value="plain" data-i18n="label.plain"></option>
+            <option value="mustache" data-i18n="label.mustache"></option>
         </select>
     </div>
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
It reverts a change, in order to comply with the commentary in dojot/flowbroker#130 this PR brings back the mustache engine in the template node to make it retro-compatible.


* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)
dojot/flowbroker#130

* **Other information**:
