### PR TITLE
feat: adding device timetstamp to message metadata

### DIFF
--- a/orchestrator/executor.js
+++ b/orchestrator/executor.js
@@ -44,7 +44,8 @@ module.exports = class Executor {
             let metadata = {
                 flowId: event.flow.id,
                 tenant: event.metadata.tenant,
-                originatorDeviceId: event.metadata.originator
+                originatorDeviceId: event.metadata.originator,
+                timestamp: event.metadata.timestamp,
             }
             handler.handleMessage(at, event.message, metadata, this.contextHandler)
                 .then((result) => {

--- a/orchestrator/ingestor.js
+++ b/orchestrator/ingestor.js
@@ -116,7 +116,8 @@ module.exports = class DeviceIngestor {
           flow: flow,
           metadata: {
             tenant: metadata.tenant,
-            originator: metadata.deviceid
+            originator: metadata.deviceid,
+            timestamp: metadata.timestamp,
           }
         }), 0);
       }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


* **What is the current behavior?** (You can also link to an open issue here)
The timestamp associated to the input message (which was created by a device, IoT agent or Flowbroker) cannot be accessed by nodes.

* **What is the new behavior (if this is a feature change)?**
This commit adds timestamp (generated by the device, IoT agent or Flowbroker itself)
to the metadata sent to flow nodes.
At first, this feature will be used by FTP node to set the filename to be used when uploading data (but this PR has no dependency with FTP node)

The metadata available to a particular node will be:
```json
{
  "flowId": "182f2a51-5302-4946-b9b8-bc312d7af8fa",
  "tenant": "admin",
  "originatorDeviceId": "9c1a03",
  "timestamp": 1554730062038
}
```
* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)
Yes, this is connected to dojot/dojot#1010 (loosely)

* **Other information**:
