### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,7 +86,7 @@ jobs:
       uses: actions/checkout@v1
 
     - name: Build and Push
-      uses: elgohr/Publish-Docker-Github-Action@2.16
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{ steps.get_owner.outputs.owner }}/flowbroker
         username: ${{ secrets.DOCKER_USERNAME }}
@@ -98,7 +98,7 @@ jobs:
         tag_names: true
 
     - name: Build and Push
-      uses: elgohr/Publish-Docker-Github-Action@2.16
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{ steps.get_owner.outputs.owner }}/flowbroker-context-manager
         username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore